### PR TITLE
[#4408] Add roll data to journal entry pages

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -67,6 +67,7 @@ Hooks.once("init", function() {
   CONFIG.Item.collection = dataModels.collection.Items5e;
   CONFIG.Item.compendiumIndexFields.push("system.container");
   CONFIG.Item.documentClass = documents.Item5e;
+  CONFIG.JournalEntryPage.documentClass = documents.JournalEntryPage5e;
   CONFIG.Token.documentClass = documents.TokenDocument5e;
   CONFIG.Token.objectClass = canvas.Token5e;
   CONFIG.User.documentClass = documents.User5e;

--- a/module/documents/_module.mjs
+++ b/module/documents/_module.mjs
@@ -7,6 +7,7 @@ export {default as ChatMessage5e} from "./chat-message.mjs";
 export {default as Combat5e} from "./combat.mjs";
 export {default as Combatant5e} from "./combatant.mjs";
 export {default as Item5e} from "./item.mjs";
+export {default as JournalEntryPage5e} from "./journal-entry-page.mjs";
 export {default as TokenDocument5e} from "./token.mjs";
 export {default as User5e} from "./user.mjs";
 

--- a/module/documents/journal-entry-page.mjs
+++ b/module/documents/journal-entry-page.mjs
@@ -1,0 +1,17 @@
+/**
+ * Custom implementation of journal entry pages for providing roll data.
+ */
+export default class JournalEntryPage5e extends JournalEntryPage {
+  /**
+   * Return a data object regarding this page and from the containing journal entry.
+   * @returns {object}
+   */
+  getRollData() {
+    const { name, flags, system } = this;
+    return {
+      name: this.parent.name,
+      flags: this.parent.flags,
+      page: { ...system, name, flags }
+    };
+  }
+}

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -419,7 +419,7 @@ function enrichLookup(config, fallback, options) {
     return null;
   }
 
-  const data = options.relativeTo?.getRollData();
+  const data = options.relativeTo?.getRollData?.() ?? {};
   let value = foundry.utils.getProperty(data, keyPath.substring(1)) ?? fallback;
   if ( value && style ) {
     if ( style === "capitalize" ) value = value.capitalize();


### PR DESCRIPTION
Adds a new `JournalEntryPage5e` with a `getRollData` method that provides the journal entry's name and flags as well as the page's name, flags, and system data.

Also fixes a bug with the `[[lookup]]` enricher causing it to throw an error if used on a document that doesn't provide the `getRollData` method.

Closes #4408